### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ A React Component for Progressive Image Loading.
 [![devDependency Status](https://david-dm.org/Gattermeier/lazyimage/dev-status.svg)](https://david-dm.org/Gattermeier/lazyimage#info=devDependencies)
 
 
-LazyImage loads a low res version of an image blurred before replacing it with a larger, higher-res image after it was loaded completely. Inspired by a blog article on Medium's progressive image loading by José Manuel Pérez: https://jmperezperez.com/medium-image-progressive-loading-placeholder/
+LazyImage loads a low-res version of an image blurred before replacing it with a larger, higher-res image after it was loaded completely. Inspired by a blog article on Medium's progressive image loading by José Manuel Pérez: https://jmperezperez.com/medium-image-progressive-loading-placeholder/
 
 ## Install via npm    
 `npm i --save lazyimage`    
 
-## Useage
+## Usage
 ```javascript
 import LazyImage from 'lazyimage'
 
@@ -23,9 +23,14 @@ import LazyImage from 'lazyimage'
   width="600"
   height="190"
   src="/path/to/very/large/image"
-  small="/path/to/low/quality/image" 
+  low="/path/to/low/quality/image"
 />
 ```
+
+## Features    
+* If no `low`-resolution source is provided a regular image is rendered.
+* `blurRadius` defaults to `10`
+
 
 ## Tests
 Uses [Lab](https://github.com/hapijs/lab), [Code](https://github.com/hapijs/code), [Enzyme](https://github.com/airbnb/enzyme) for unit tests. If you want to know more about React unit testing using Lab instead of Mocha or Tape read the [blog post on Medium](https://medium.com/@gattermeier/react-unit-testing-with-enzyme-lab-and-code-24dad077f6d4#.3lawhddx2)

--- a/example/package.json
+++ b/example/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "babel-runtime": "^6.3.19",
-    "lazyimage": "^2.0.2",
     "react": "^15.1.0",
     "react-dom": "^15.1.0"
   }

--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import LazyImage from 'lazyimage';
+import LazyImage from '../../lib/index.js'
 
 const App = (props) => (
   <div>

--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -9,8 +9,9 @@ const App = (props) => (
       width={600}
       height={190}
       src="https://upload.wikimedia.org/wikipedia/commons/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
-      small="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg/800px-Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
+      low="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg/800px-Very_Large_Telescope_Ready_for_Action_%28ESO%29.jpg"
     />
+
   </div>
 )
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,15 +1,18 @@
-const Path = require('path');
+const path = require('path');
 
 module.exports = {
   entry: [
      'babel-polyfill',
-     Path.join(__dirname, './src/index.jsx')
+     path.join(__dirname, './src/index.jsx')
   ],
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    alias: {
+      react: path.resolve('./node_modules/react'),
+    }
   },
   output: {
-    filename: Path.join(__dirname, './lib/index.js')
+    filename: path.join(__dirname, './lib/index.js')
   },
   module: {
     loaders: [{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lazyimage",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "description": "A React Component for Progressive (Lazy) Image Loading",
   "main": "lib/index.js",
   "dependencies": {

--- a/shared/styles.js
+++ b/shared/styles.js
@@ -1,17 +1,21 @@
 module.exports = {
   LazyImage: {
     true: {
+      display: 'none',
       opacity: 0,
     },
     false: {
+      display: 'block',
       opacity: 1,
     }
   },
   FullImage: {
     true: {
+      display: 'block',
       opacity: 1,
     },
     false: {
+      display: 'none',
       opacity: 0,
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,32 +17,36 @@ class LazyImageWrapper extends React.Component {
     })
   }
   render() {
-    const { src, small, width, height, blurRadius } = this.props;
+    const { src, low, width, height, blurRadius } = this.props;
+
     const styles = {
       width,
       height,
       padding: 0,
       margin: 0,
-      position: 'absolute',
       top: 0,
     }
 
-    const ease = {
-      WebkitTransition: 'opacity 250ms ease-in-out',
-      MozTransition: 'opacity 250ms ease-in-out',
-      OTransition: 'opacity 250ms ease-in-out',
-      transition: 'opacity 250ms ease-in-out',
-    }
-
-    const wrapperStyles = {
-      paddingBottom: styles.height,
-      position: 'relative'
+    if (!this.props.low) {
+      return <img src={src} style={styles} />
     }
 
     return (
-      <div style={wrapperStyles}>
-        <FullImage src={src} style={getStyles('FullImage', styles, this.state.loaded)} onLoad={this.handleLoaded} />
-        <LazyImage src={small} width={width} height={height} style={getStyles('LazyImage', Object.assign({}, ease, styles), this.state.loaded)} blurRadius={this.props.blurRadius}/>
+      <div>
+        <FullImage
+          src={src}
+          style={getStyles('FullImage', styles, this.state.loaded)}
+          onLoad={this.handleLoaded}
+        />
+        {!this.state.loaded &&
+          <LazyImage
+            src={low}
+            width={width}
+            height={height}
+            style={getStyles('LazyImage', styles, this.state.loaded)}
+            blurRadius={this.props.blurRadius}
+          />
+        }
       </div>
     )
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import FullImage from './FullImage'
 import LazyImage from './LazyImage'
-
 import getStyles from '../shared/getStyles'
 
 class LazyImageWrapper extends React.Component {
@@ -25,7 +24,14 @@ class LazyImageWrapper extends React.Component {
       padding: 0,
       margin: 0,
       position: 'absolute',
-      top: 0
+      top: 0,
+    }
+
+    const ease = {
+      WebkitTransition: 'opacity 250ms ease-in-out',
+      MozTransition: 'opacity 250ms ease-in-out',
+      OTransition: 'opacity 250ms ease-in-out',
+      transition: 'opacity 250ms ease-in-out',
     }
 
     const wrapperStyles = {
@@ -36,7 +42,7 @@ class LazyImageWrapper extends React.Component {
     return (
       <div style={wrapperStyles}>
         <FullImage src={src} style={getStyles('FullImage', styles, this.state.loaded)} onLoad={this.handleLoaded} />
-        <LazyImage src={small} width={width} height={height} style={getStyles('LazyImage', styles, this.state.loaded)} blurRadius={this.props.blurRadius}/>
+        <LazyImage src={small} width={width} height={height} style={getStyles('LazyImage', Object.assign({}, ease, styles), this.state.loaded)} blurRadius={this.props.blurRadius}/>
       </div>
     )
   }


### PR DESCRIPTION
- resolve `React` locally on webpack build in example to avoid duplicate `React` reference issues
- drops absolute positioning
- renames `small` prop to `low` prop
